### PR TITLE
Fix link to our careers page

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ At Embark, we aspire to empower everyone to create interactive experiences. To d
 
 If you have ideas for collaboration, email us at opensource@embark-studios.com.
 
-We're also hiring full-time engineers to work with us in Stockholm! Check out our current job postings [here](https://embark.games/careers).
+We're also hiring full-time engineers to work with us in Stockholm! Check out our current job postings [here](https://www.embark-studios.com/jobs).
 
 ## Issues
 


### PR DESCRIPTION
Got a [PR](https://github.com/EmbarkStudios/sentry-contrib-rust/pull/2) on another repo that noticed our job page link was 404ing, this needs to be updated in all of our repos.
