### PR TITLE
Add container image build job to CI

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -177,3 +177,41 @@ jobs:
           files: "$BIN_NAME*"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # TODO: Remove this job if you don't publish container images on each release
+  # TODO: Create a repository on DockerHub with the same name as the GitHub repo
+  # TODO: Add the new repo to the buildbot group with read & write permissions 
+  # TODO: Add the embarkbot dockerhub password to the repo secrets as DOCKERHUB_PASSWORD
+  publish-container-images:
+    name: Publish container images
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/')
+    needs: [test, deny-check]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Login to Dockerhub
+        uses: docker/login-action@v1 
+        with:
+          username: embarkbot
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+      - name: Docker meta
+        id: docker_meta
+        uses: crazy-max/ghaction-docker-meta@v1
+        with:
+          images: embarkstudios/${{ github.event.repository.name }}
+          tag-semver: |
+            {{version}}
+            {{major}}.{{minor}}
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: ${{ steps.docker_meta.outputs.tags }}
+          labels: ${{ steps.docker_meta.outputs.labels }}


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

I was adding this to Octobors and I thought it would be generally useful.

Example run: https://github.com/EmbarkStudios/oss-container-build-test/runs/1854123145?check_suite_focus=true
Example output: https://hub.docker.com/repository/docker/embarkstudios/oss-container-build-test

I wanted to add the GitHub container registry too but it seems that isn't enabled for our account yet.