### PR TITLE
Switch `no-dev-version` to `dev-version`

### DIFF
--- a/release.toml
+++ b/release.toml
@@ -1,5 +1,5 @@
 pre-release-commit-message = "Release {{version}}"
-no-dev-version = true
+dev-version = false
 tag-message = "Release {{version}}"
 tag-name = "{{version}}"
 pre-release-replacements = [


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

Updates the release.toml to work with recent versions of cargo-release. They switched some flags around in 0.19.0 to not require double negations.

https://github.com/crate-ci/cargo-release/blob/master/CHANGELOG.md#0190---2022-01-07
